### PR TITLE
fix: 4 demo-breaking bugs in result page and persons page

### DIFF
--- a/src/app/dashboard/persons/page.tsx
+++ b/src/app/dashboard/persons/page.tsx
@@ -265,7 +265,7 @@ export default function PersonsPage() {
             <p className="text-it2p-text-secondary mb-4">
               {filter === 'all'
                 ? 'Commencez par créer votre premier coaché'
-                : 'Essayez de changer le filtre pour voir d'autres coachés'}
+                : "Essayez de changer le filtre pour voir d'autres coachés"}
             </p>
             {filter === 'all' && (
               <button

--- a/src/app/dashboard/session/[id]/page.tsx
+++ b/src/app/dashboard/session/[id]/page.tsx
@@ -31,7 +31,7 @@ export default async function SessionPage({ params }: PageProps) {
   // Get session ID
   const { id } = await params
 
-  // Get session with answers and result
+  // Get session with answers, result, and person
   const sessionData = await prisma.session.findUnique({
     where: { id },
     include: {
@@ -39,6 +39,7 @@ export default async function SessionPage({ params }: PageProps) {
         orderBy: { question: 'asc' },
       },
       result: true,
+      person: true,
     },
   })
 
@@ -97,7 +98,9 @@ export default async function SessionPage({ params }: PageProps) {
   const metadata = {
     date: formatDate(sessionData.createdAt),
     analysedFor: sessionData.context || 'Bilan A2P',
-    coacheeName: sessionData.coacheeName || undefined,
+    coacheeName: sessionData.person
+      ? `${sessionData.person.firstName} ${sessionData.person.lastName}`
+      : sessionData.coacheeName || undefined,
     profileCode: result.profileCode,
     profileName: result.profileName,
     resultCode: `F${scores.F} R${scores.R} P${scores.P} M${scores.M}`,
@@ -137,9 +140,11 @@ export default async function SessionPage({ params }: PageProps) {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
           <div>
-            <span className="font-medium text-it2p-text">Coaché(e):</span>
+            <span className="font-medium text-it2p-text">Coaché(e) :</span>
             <span className="ml-2 text-it2p-text-secondary">
-              {sessionData.coacheeName || 'Non renseigné'}
+              {sessionData.person
+                ? `${sessionData.person.firstName} ${sessionData.person.lastName}`
+                : sessionData.coacheeName || 'Non renseigné'}
             </span>
           </div>
           {sessionData.context && (
@@ -168,7 +173,7 @@ export default async function SessionPage({ params }: PageProps) {
             <div className="grid grid-cols-2 gap-4">
               <div className="bg-it2p-surface border border-it2p-sand/30 rounded-lg p-4 shadow-sm">
                 <div className="text-sm font-medium text-it2p-text-secondary mb-1">
-                  F - Flexibility
+                  F — Réflexion
                 </div>
                 <div className="text-3xl font-bold text-it2p-accent">
                   {scores.F}
@@ -177,7 +182,7 @@ export default async function SessionPage({ params }: PageProps) {
 
               <div className="bg-it2p-surface border border-it2p-sand/30 rounded-lg p-4 shadow-sm">
                 <div className="text-sm font-medium text-it2p-text-secondary mb-1">
-                  R - Relationship
+                  R — Rigueur
                 </div>
                 <div className="text-3xl font-bold text-it2p-accent">
                   {scores.R}
@@ -186,7 +191,7 @@ export default async function SessionPage({ params }: PageProps) {
 
               <div className="bg-it2p-surface border border-it2p-sand/30 rounded-lg p-4 shadow-sm">
                 <div className="text-sm font-medium text-it2p-text-secondary mb-1">
-                  P - Position
+                  P — Implication personnelle
                 </div>
                 <div className="text-3xl font-bold text-it2p-accent">
                   {scores.P}
@@ -195,7 +200,7 @@ export default async function SessionPage({ params }: PageProps) {
 
               <div className="bg-it2p-surface border border-it2p-sand/30 rounded-lg p-4 shadow-sm">
                 <div className="text-sm font-medium text-it2p-text-secondary mb-1">
-                  M - Matter
+                  M — Efficacité concrète
                 </div>
                 <div className="text-3xl font-bold text-it2p-accent">
                   {scores.M}


### PR DESCRIPTION
## Bugs fixed

### 1. Wrong axis labels (critical)
The score cards on the result page showed fabricated English labels:
- "F - Flexibility" → **F — Réflexion**
- "R - Relationship" → **R — Rigueur**
- "P - Position" → **P — Implication personnelle**
- "M - Matter" → **M — Efficacité concrète**

These are the correct IA2P axis names from the spec (§3 `scoreF` / `scoreR` / `scoreP` / `scoreM`).

### 2. Person name missing on result page
The Prisma query in `session/[id]/page.tsx` did not include `person: true`, so the "Coaché(e)" field always fell back to the deprecated `coacheeName` field — showing **"Non renseigné"** for any session created after the Person model was introduced (i.e. every live demo session).

Fix: added `person: true` to the query, display `firstName + lastName` with fallback chain → `coacheeName` → "Non renseigné".

### 3. Person name missing in RoueA2P SVG header
Same root cause: the `coacheeName` metadata prop passed to `<RoueA2P>` was always `undefined` for new sessions, so the printed SVG header showed no name.

Fix: resolved name fed into `metadata.coacheeName` using the same fallback chain.

### 4. JSX syntax error in persons page
A straight apostrophe inside a single-quoted JSX string literal broke TypeScript compilation:
```
'Essayez de changer le filtre pour voir d'autres coachés'
                                        ^ breaks here
```
Fixed by switching to double quotes.